### PR TITLE
fix: Separate packet transmission type and id

### DIFF
--- a/src/server/EA/Constants.cs
+++ b/src/server/EA/Constants.cs
@@ -13,3 +13,18 @@ public static class Beach
     public const int FeslPort = 18231;
     public const int TheaterPort = 18236;
 }
+
+public static class FeslTransmissionType
+{
+    public const uint Ping = 0x00000000;
+    public const uint SinglePacketResponse = 0x80000000;
+    public const uint MultiPacketResponse = 0xb0000000;
+    public const uint SinglePacketRequest = 0xc0000000;
+    public const uint MultiPacketRequest = 0xf0000000;
+}
+
+public static class TheaterTransmissionType
+{
+    public const uint Request = 0x40000000;
+    public const uint OkResponse = 0x00000000;
+}

--- a/src/server/EA/PacketUtils.cs
+++ b/src/server/EA/PacketUtils.cs
@@ -13,15 +13,17 @@ public static class PacketUtils
         return seed.ToString();
     }
 
-    public static byte[] GeneratePacketChecksum(string data, uint id)
+    public static byte[] BuildPacketHeader(string type, uint transmissionType, uint packetId, string data)
     {
-        byte[] packetIdBytes = GeneratePacketId(id);
-        byte[] packetLengthBytes = GeneratePacketLength(data);
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        // TODO Check if bitwise OR is enough or if we need to apply the bit mask first to not break anything with packet ids longer than 3 bytes
+        var transmissionTypePacketIdBytes = UintToBytes(transmissionType | packetId);
+        var packetLengthBytes = CalcPacketLength(data);
 
-        return packetIdBytes.Concat(packetLengthBytes).ToArray();
+        return typeBytes.Concat(transmissionTypePacketIdBytes).Concat(packetLengthBytes).ToArray();
     }
 
-    private static byte[] GeneratePacketLength(string packetData)
+    private static byte[] CalcPacketLength(string packetData)
     {
         var dataBytes = Encoding.ASCII.GetBytes(packetData);
 
@@ -34,9 +36,9 @@ public static class PacketUtils
         return bytes;
     }
 
-    private static byte[] GeneratePacketId(uint packetId)
+    private static byte[] UintToBytes(uint value)
     {
-        byte[] bytes = BitConverter.GetBytes(packetId);
+        byte[] bytes = BitConverter.GetBytes(value);
 
         if (BitConverter.IsLittleEndian)
             Array.Reverse(bytes);

--- a/src/server/EA/Proxy/FeslProxy.cs
+++ b/src/server/EA/Proxy/FeslProxy.cs
@@ -143,7 +143,7 @@ public class FeslProxy
                         var dataStringMod = packet.DataDict.Select(x => $"{x.Key}={x.Value}").Aggregate((x, y) => $"{x}; {y}");
                         _logger.LogDebug($"Rewritten id={packet.Id} len={packet.Length} {packet.Type}, data: {dataStringMod}");
 
-                        var newBuffer = await packet.Serialize(packet.Id);
+                        var newBuffer = await packet.Serialize();
 
                         read = newBuffer.Length;
                         Array.Copy(newBuffer, readBuffer, read.Value);

--- a/src/server/Handlers/TheaterHandler.cs
+++ b/src/server/Handlers/TheaterHandler.cs
@@ -1,6 +1,7 @@
 using System.Net.Sockets;
 using System.Text;
 using Arcadia.EA;
+using Arcadia.EA.Constants;
 using Arcadia.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -99,7 +100,7 @@ public class TheaterHandler
             ["PROT"] = request.DataDict["PROT"]
         };
 
-        var packet = new Packet("CONN", 0x00000000, response);
+        var packet = new Packet("CONN", TheaterTransmissionType.OkResponse, 0, response);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -118,7 +119,7 @@ public class TheaterHandler
             ["TID"] = request.DataDict["TID"]
         };
 
-        var packet = new Packet("USER", 0x00000000, response);
+        var packet = new Packet("USER", TheaterTransmissionType.OkResponse, 0, response);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -140,7 +141,7 @@ public class TheaterHandler
             ["GID"] = _sharedCounters.GetNextGameId()
         };
 
-        var packet = new Packet("CGAM", 0x00000000, response);
+        var packet = new Packet("CGAM", TheaterTransmissionType.OkResponse, 0, response);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -159,7 +160,7 @@ public class TheaterHandler
             ["GID"] = request.DataDict["GID"],
         };
 
-        var packet = new Packet("ECNL", 0x00000000, response);
+        var packet = new Packet("ECNL", TheaterTransmissionType.OkResponse, 0, response);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -175,7 +176,7 @@ public class TheaterHandler
             ["GID"] = request.DataDict["GID"]
         };
 
-        var packet = new Packet("EGAM", 0x00000000, response);
+        var packet = new Packet("EGAM", TheaterTransmissionType.OkResponse, 0, response);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -190,7 +191,7 @@ public class TheaterHandler
             ["TID"] = request.DataDict["TID"]
         };
 
-        var packet = new Packet("EGRS", 0x00000000, serverInfo);
+        var packet = new Packet("EGRS", TheaterTransmissionType.OkResponse, 0, serverInfo);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -237,7 +238,7 @@ public class TheaterHandler
             ["AP"] = 5
         };
 
-        var packet = new Packet("GDAT", 0x00000000, serverInfo);
+        var packet = new Packet("GDAT", TheaterTransmissionType.OkResponse, 0, serverInfo);
         var data = await packet.Serialize();
         await _network.WriteAsync(data);
 
@@ -261,7 +262,7 @@ public class TheaterHandler
             serverInfo.Add($"D-pdat{i}", "|0|0|0|0");
         }
 
-        var packet = new Packet("GDET", 0x00000000, serverInfo);
+        var packet = new Packet("GDET", TheaterTransmissionType.OkResponse, 0, serverInfo);
         var data = await packet.Serialize();
 
         _logger.LogTrace("Sending GDET to client at {endpoint}", _clientEndpoint);
@@ -276,7 +277,7 @@ public class TheaterHandler
             ["PID"] = request.DataDict["PID"],
         };
 
-        var packet = new Packet("PENT", 0x00000000, serverInfo);
+        var packet = new Packet("PENT", TheaterTransmissionType.OkResponse, 0, serverInfo);
         var data = await packet.Serialize();
 
         await _network.WriteAsync(data);
@@ -306,7 +307,7 @@ public class TheaterHandler
             ["GID"] = request.DataDict["GID"]
         };
 
-        var packet = new Packet("EGEG", 0x00000000, serverInfo);
+        var packet = new Packet("EGEG", TheaterTransmissionType.OkResponse, 0, serverInfo);
         var data = await packet.Serialize();
 
         _logger.LogTrace("Sending EGEG to client at {endpoint}", _clientEndpoint);
@@ -334,7 +335,7 @@ public class TheaterHandler
             ["GID"] = 801000
         };
 
-        var packet = new Packet("EGRQ", 0x00000000, serverInfo);
+        var packet = new Packet("EGRQ", TheaterTransmissionType.OkResponse, 0, serverInfo);
         var data = await packet.Serialize();
 
         _logger.LogTrace("Sending EGRQ to client at {endpoint}", _clientEndpoint);

--- a/src/tests/EAPacketTests.cs
+++ b/src/tests/EAPacketTests.cs
@@ -26,6 +26,8 @@ public class EAPacketTests
         var packet = new Packet(Utils.HexStringToBytes(request));
 
         Assert.Equal("fsys", packet.Type);
+        Assert.Equal((uint)1, packet.Id);
+        Assert.Equal(0xc0000000, packet.TransmissionType);
         Assert.Equal("Hello", packet["TXN"]);
     }
 }


### PR DESCRIPTION
Properly handle the transmission type and packet id in the header when reading/building packets.

Also refactored some methods to make them a bit more readable and/or name them more according to what they do.