### PR TITLE
feat: Provide app settings to override join now game

### DIFF
--- a/src/server/AppSettings.cs
+++ b/src/server/AppSettings.cs
@@ -24,6 +24,10 @@ public record FeslSettings
     public bool DumpClientTicket { get; init; }
     public string ProxyOverrideClientTicket { get; init; } = string.Empty;
     public string ProxyOverrideClientMacAddr { get; init; } = string.Empty;
+    public string ProxyOverrideTheaterIp { get; init; } = string.Empty;
+    public int ProxyOverrideTheaterPort { get; init; } = 0;
+    public int ProxyOverridePlayNowGameGid { get; init; } = 0;
+    public int ProxyOverridePlayNowGameLid { get; init; } = 0;
 }
 
 public record DnsSettings

--- a/src/server/EA/Proxy/TheaterProxy.cs
+++ b/src/server/EA/Proxy/TheaterProxy.cs
@@ -36,7 +36,7 @@ public class TheaterProxy
 
     private void InitializeUpstreamClient()
     {
-        _upstreamClient = new TcpClient("beach-ps3.theater.ea.com", _config.TheaterPort);
+        _upstreamClient = new TcpClient(_config.TheaterAddress, _config.TheaterPort);
         _upstreamStream = _upstreamClient.GetStream();
     }
 


### PR DESCRIPTION
Actually adds two override options, I noticed too late that the play now game override actually does not rely on the theater override. But both are nice to have.

Also fixed  a small bug with the upstream theater address being hard coded.