### PR TITLE
Add email login override feature

### DIFF
--- a/src/server/AppSettings.cs
+++ b/src/server/AppSettings.cs
@@ -26,6 +26,8 @@ public record FeslSettings
     public string ProxyOverrideClientMacAddr { get; init; } = string.Empty;
     public string ProxyOverrideTheaterIp { get; init; } = string.Empty;
     public int ProxyOverrideTheaterPort { get; init; } = 0;
+    public string ProxyOverrideAccountEmail { get; init; } = string.Empty;
+    public string ProxyOverrideAccountPassword { get; init; } = string.Empty;
     public int ProxyOverridePlayNowGameGid { get; init; } = 0;
     public int ProxyOverridePlayNowGameLid { get; init; } = 0;
 }

--- a/src/server/EA/Proxy/FeslProxy.cs
+++ b/src/server/EA/Proxy/FeslProxy.cs
@@ -17,6 +17,8 @@ public class FeslProxy
     private TlsClientProtocol? _upstreamProtocol;
     private BcTlsCrypto? _crypto;
 
+    private string? _personaName;
+
     public FeslProxy(ILogger<FeslProxy> logger, IOptions<FeslSettings> settings)
     {
         _logger = logger;
@@ -118,75 +120,72 @@ public class FeslProxy
             }
 
             var feslPacket = AnalyzeFeslPacket(readBuffer.AsSpan(0, read.Value).ToArray());
-            var dataString = feslPacket?.DataDict.Select(x => $"{x.Key}={x.Value}").Aggregate((x, y) => $"{x}; {y}");
-            _logger.LogTrace($"Proxying id={feslPacket?.Id} len={feslPacket?.Length} {feslPacket?.Type}, data: {dataString}");
+            LogPacket("Proxying", feslPacket);
 
-            if (feslPacket != null && feslPacket?.Type == "fsys" && feslPacket?["TXN"] == "Hello")
+            var enableTheaterOverride = !string.IsNullOrWhiteSpace(_settings.ProxyOverrideTheaterIp) ||
+                                        _settings.ProxyOverrideTheaterPort != 0;
+            if (enableTheaterOverride &&
+                feslPacket is { Type: "fsys", TransmissionType: FeslTransmissionType.SinglePacketResponse } &&
+                feslPacket?["TXN"] == "Hello")
             {
                 var packet = feslPacket.Value;
-                var theaterIp = packet["theaterIp"];
-                var theaterPort = packet["theaterPort"];
 
-                if (!string.IsNullOrWhiteSpace(theaterIp) && !string.IsNullOrWhiteSpace(theaterPort) && (!string.IsNullOrWhiteSpace(_settings.ProxyOverrideTheaterIp) || _settings.ProxyOverrideTheaterPort != 0))
+                _logger.LogInformation("Overriding server theater details...");
+
+                if (!string.IsNullOrWhiteSpace(_settings.ProxyOverrideTheaterIp))
                 {
-                    _logger.LogInformation("Overriding server theater details...");
-
-                    if (!string.IsNullOrWhiteSpace(_settings.ProxyOverrideTheaterIp))
-                    {
-                        packet["theaterIp"] = _settings.ProxyOverrideTheaterIp;                        
-                    }
-
-                    if (_settings.ProxyOverrideTheaterPort != 0)
-                    {
-                        packet["theaterPort"] = _settings.ProxyOverrideTheaterPort.ToString();                        
-                    }
-                    
-                    var newBuffer = await packet.Serialize();
-
-                    read = newBuffer.Length;
-                    Array.Copy(newBuffer, readBuffer, read.Value);
-                    
-                    var dataStringMod = feslPacket?.DataDict.Select(x => $"{x.Key}={x.Value}").Aggregate((x, y) => $"{x}; {y}");
-                    _logger.LogTrace($"FESL packet with override id={feslPacket?.Id} len={feslPacket?.Length} {feslPacket?.Type}, data: {dataStringMod}");
+                    packet["theaterIp"] = _settings.ProxyOverrideTheaterIp;
                 }
+
+                if (_settings.ProxyOverrideTheaterPort != 0)
+                {
+                    packet["theaterPort"] = _settings.ProxyOverrideTheaterPort.ToString();
+                }
+
+                var newBuffer = await packet.Serialize();
+
+                read = newBuffer.Length;
+                Array.Copy(newBuffer, readBuffer, read.Value);
+                
+                LogPacket("Packet after override", packet);
             }
-            
-            if (feslPacket != null && feslPacket?.Type == "pnow" && feslPacket?["TXN"] == "Status")
+
+            var enablePlayNowGameOverride =
+                _settings.ProxyOverridePlayNowGameGid != 0 && _settings.ProxyOverridePlayNowGameLid != 0;
+            if (enablePlayNowGameOverride &&
+                feslPacket is { Type: "pnow", TransmissionType: FeslTransmissionType.SinglePacketResponse } &&
+                feslPacket?["TXN"] == "Status")
             {
                 var packet = feslPacket.Value;
-                var sessionState = packet["sessionState"];
 
-                if (!string.IsNullOrWhiteSpace(sessionState) && _settings.ProxyOverridePlayNowGameGid != 0 && _settings.ProxyOverridePlayNowGameLid != 0)
+                _logger.LogInformation("Overriding server play now response...");
+
+                var pnowData = new Dictionary<string, object>
                 {
-                    _logger.LogInformation("Overriding server play now response...");
-                    
-                    var pnowData = new Dictionary<string, object>
-                    {
-                        { "TXN", "Status" },
-                        { "id.id", packet["id.id"] },
-                        { "id.partition", packet["id.partition"] },
-                        { "sessionState", "COMPLETE" },
-                        { "props.{}", 2 },
-                        { "props.{resultType}", "JOIN" },
-                        { "props.{games}.[]", 1 },
-                        { "props.{games}.0.fit", 3349 },
-                        { "props.{games}.0.gid", _settings.ProxyOverridePlayNowGameGid },
-                        { "props.{games}.0.lid", _settings.ProxyOverridePlayNowGameLid }
-                    };
+                    { "TXN", "Status" },
+                    { "id.id", packet["id.id"] },
+                    { "id.partition", packet["id.partition"] },
+                    { "sessionState", "COMPLETE" },
+                    { "props.{}", 2 },
+                    { "props.{resultType}", "JOIN" },
+                    { "props.{games}.[]", 1 },
+                    { "props.{games}.0.fit", 3349 },
+                    { "props.{games}.0.gid", _settings.ProxyOverridePlayNowGameGid },
+                    { "props.{games}.0.lid", _settings.ProxyOverridePlayNowGameLid }
+                };
 
-                    var pnowPacket = new Packet("pnow", FeslTransmissionType.SinglePacketResponse, packet.Id, pnowData);
-                    
-                    var newBuffer = await pnowPacket.Serialize();
+                var pnowPacket = new Packet("pnow", FeslTransmissionType.SinglePacketResponse, packet.Id, pnowData);
 
-                    read = newBuffer.Length;
-                    Array.Copy(newBuffer, readBuffer, read.Value);
-                    
-                    var dataStringMod = pnowPacket.DataDict.Select(x => $"{x.Key}={x.Value}").Aggregate((x, y) => $"{x}; {y}");
-                    _logger.LogTrace($"FESL packet with override id={pnowPacket.Id} len={pnowPacket.Length} {pnowPacket.Type}, data: {dataStringMod}");
-                }
+                var newBuffer = await pnowPacket.Serialize();
+
+                read = newBuffer.Length;
+                Array.Copy(newBuffer, readBuffer, read.Value);
+                
+                LogPacket("Packet after override", pnowPacket);
             }
 
-            if (feslPacket != null && feslPacket?.Type == "acct" && feslPacket?["TXN"] == "NuPS3Login")
+            if (feslPacket is { Type: "acct", TransmissionType: FeslTransmissionType.SinglePacketRequest } &&
+                feslPacket?["TXN"] == "NuPS3Login")
             {
                 var packet = feslPacket.Value;
                 var clientTicket = packet["ticket"];
@@ -197,7 +196,8 @@ public class FeslProxy
                     throw new Exception("Ticket dumped, exiting...");
                 }
 
-                if (!string.IsNullOrWhiteSpace(clientTicket) && !string.IsNullOrWhiteSpace(_settings.ProxyOverrideClientTicket))
+                if (!string.IsNullOrWhiteSpace(clientTicket) &&
+                    !string.IsNullOrWhiteSpace(_settings.ProxyOverrideClientTicket))
                 {
                     try
                     {
@@ -206,13 +206,12 @@ public class FeslProxy
                         packet["ticket"] = _settings.ProxyOverrideClientTicket;
                         packet["macAddr"] = _settings.ProxyOverrideClientMacAddr;
 
-                        var dataStringMod = packet.DataDict.Select(x => $"{x.Key}={x.Value}").Aggregate((x, y) => $"{x}; {y}");
-                        _logger.LogDebug($"Rewritten id={packet.Id} len={packet.Length} {packet.Type}, data: {dataStringMod}");
-
                         var newBuffer = await packet.Serialize();
 
                         read = newBuffer.Length;
                         Array.Copy(newBuffer, readBuffer, read.Value);
+
+                        LogPacket("Packet after override", packet);
                     }
                     catch (Exception e)
                     {
@@ -227,8 +226,143 @@ public class FeslProxy
                 }
             }
 
+            var enableLoginOverride = !string.IsNullOrWhiteSpace(_settings.ProxyOverrideAccountEmail) &&
+                                      !string.IsNullOrWhiteSpace(_settings.ProxyOverrideAccountPassword);
+            if (enableLoginOverride &&
+                feslPacket is { Type: "acct", TransmissionType: FeslTransmissionType.SinglePacketRequest } &&
+                feslPacket?["TXN"] == "NuPS3Login")
+            {
+                var packet = feslPacket.Value;
+                var macAddr = !string.IsNullOrWhiteSpace(_settings.ProxyOverrideClientMacAddr)
+                    ? _settings.ProxyOverrideClientMacAddr
+                    : packet["macAddr"];
+
+                _logger.LogInformation("Overriding client login request...");
+                
+                var loginData = new Dictionary<string, object>
+                {
+                    { "TXN", "NuLogin" },
+                    { "returnEncryptedInfo", 0 },
+                    { "nuid", _settings.ProxyOverrideAccountEmail },
+                    { "password", _settings.ProxyOverrideAccountPassword },
+                    { "macAddr",  macAddr},
+                };
+
+                var loginPacket = new Packet("acct", FeslTransmissionType.SinglePacketRequest, packet.Id, loginData);
+
+                var newBuffer = await loginPacket.Serialize();
+
+                read = newBuffer.Length;
+                Array.Copy(newBuffer, readBuffer, read.Value);
+
+                LogPacket("Packet after override", loginPacket);
+            }
+
+            if (enableLoginOverride &&
+                feslPacket is { Type: "acct", TransmissionType: FeslTransmissionType.SinglePacketResponse } &&
+                feslPacket?["TXN"] == "NuLogin")
+            {
+                var packet = feslPacket.Value;
+                var lkey = packet["lkey"];
+
+                // Make sure response contains an lkey, indicating successful login
+                if (!string.IsNullOrWhiteSpace(lkey))
+                {
+                    _logger.LogInformation("Consuming server login response...");
+
+                    var getPersonasData = new Dictionary<string, object>
+                    {
+                        { "TXN", "NuGetPersonas" },
+                        { "namespace", "" },
+                    };
+
+                    var getPersonasPacket = new Packet("acct", FeslTransmissionType.SinglePacketRequest, packet.Id,
+                        getPersonasData);
+
+                    var newBuffer = await getPersonasPacket.Serialize();
+
+                    read = newBuffer.Length;
+                    Array.Copy(newBuffer, readBuffer, read.Value);
+
+                    LogPacket("Replying with packet", getPersonasPacket);
+                    source.WriteApplicationData(readBuffer, 0, read.Value);
+                    continue; // We want to consume the response, so skip sending it to the client
+                }
+            }
+
+            if (enableLoginOverride &&
+                feslPacket is { Type: "acct", TransmissionType: FeslTransmissionType.SinglePacketResponse } &&
+                feslPacket?["TXN"] == "NuGetPersonas")
+            {
+                var packet = feslPacket.Value;
+                var personaName = packet["personas.0"];
+
+                // Ensure response contains a persona we can use
+                if (!string.IsNullOrWhiteSpace(personaName))
+                {
+                    _logger.LogInformation("Consuming server get personas response...");
+
+                    var personaLoginData = new Dictionary<string, object>
+                    {
+                        { "TXN", "NuLoginPersona" },
+                        { "name", personaName },
+                    };
+
+                    var personaLoginPacket = new Packet("acct", FeslTransmissionType.SinglePacketRequest, packet.Id,
+                        personaLoginData);
+
+                    var newBuffer = await personaLoginPacket.Serialize();
+
+                    read = newBuffer.Length;
+                    Array.Copy(newBuffer, readBuffer, read.Value);
+
+                    LogPacket("Replying with packet", personaLoginPacket);
+                    source.WriteApplicationData(readBuffer, 0, read.Value);
+                    _personaName = personaName;
+                    continue; // We want to consume the response, so skip sending it to the client
+                }
+            }
+
+            if (enableLoginOverride &&
+                feslPacket is { Type: "acct", TransmissionType: FeslTransmissionType.SinglePacketResponse } &&
+                feslPacket?["TXN"] == "NuLoginPersona")
+            {
+                var packet = feslPacket.Value;
+                var lkey = packet["lkey"];
+
+                // Ensure we have both an lkey in the response and a persona name we can use
+                if (!string.IsNullOrWhiteSpace(lkey) && !string.IsNullOrWhiteSpace(_personaName))
+                {
+                    _logger.LogInformation("Overriding server profile details...");
+
+                    var loginData = new Dictionary<string, object>
+                    {
+                        { "TXN", "PS3Login" },
+                        { "userId", packet["userId"] },
+                        { "personaName", _personaName },
+                        { "lkey", lkey }
+                    };
+
+                    var loginPacket = new Packet("acct", FeslTransmissionType.SinglePacketResponse, packet.Id,
+                        loginData);
+
+                    var newBuffer = await loginPacket.Serialize();
+
+                    read = newBuffer.Length;
+                    Array.Copy(newBuffer, readBuffer, read.Value);
+
+                    LogPacket("Packet after override", loginPacket);
+                }
+            }
+
             destination.WriteApplicationData(readBuffer, 0, read.Value);
         }
+    }
+
+    private void LogPacket(string msg, Packet? packet)
+    {
+        var dataStringMod = packet?.DataDict.Select(x => $"{x.Key}={x.Value}").Aggregate((x, y) => $"{x}; {y}");
+        _logger.LogTrace($"{msg} id={packet?.Id} len={packet?.Length} {packet?.Type}, data: {dataStringMod}");
     }
 
     private static Packet? AnalyzeFeslPacket(byte[] buffer)

--- a/src/server/appsettings.json
+++ b/src/server/appsettings.json
@@ -1,6 +1,6 @@
 {
     "ArcadiaSettings": {
-        "TheaterAddress": "192.168.0.39",
+        "TheaterAddress": "beach-ps3.theater.ea.com",
         "TheaterPort": 18236,
 
         "GameServerAddress": "192.168.0.39",
@@ -12,10 +12,16 @@
         "EnableProxy": true,
         "DumpClientTicket" : false,
         "ProxyOverrideClientTicket": "",
-        "ProxyOverrideClientMacAddr": ""
+        "ProxyOverrideClientMacAddr": "",
+        "ProxyOverrideTheaterIp": "",
+        "ProxyOverrideTheaterPort": 0,
+        "ProxyOverrideAccountEmail": "",
+        "ProxyOverrideAccountPassword": "",
+        "ProxyOverridePlayNowGameGid": 0,
+        "ProxyOverridePlayNowGameLid": 0
     },
     "DnsSettings": {
-        "EnableDns": true,
+        "EnableDns": false,
         "FeslAddress" : "192.168.0.39",
         "DnsPort": 53
     },


### PR DESCRIPTION
Adds the option to completely override the ticket-based login and log in via email and password instead, eliminating the need for a valid PS3 ticket.