### PR TITLE
fix: Handle proxy write errors

### DIFF
--- a/src/server/EA/EAPacket.cs
+++ b/src/server/EA/EAPacket.cs
@@ -36,6 +36,11 @@ public readonly struct Packet
         DataDict = dataDict ?? new Dictionary<string, object>();
     }
 
+    public Packet Clone()
+    {
+        return new Packet(Type, TransmissionType, Id, DataDict);
+    }
+
     public async Task<byte[]> Serialize()
     {
         var data = Utils.DataDictToPacketString(DataDict).ToString();

--- a/src/server/EA/Proxy/TheaterProxy.cs
+++ b/src/server/EA/Proxy/TheaterProxy.cs
@@ -85,6 +85,6 @@ public class TheaterProxy
         });
 
         await Task.WhenAny(clientToUpstreamTask, upstreamToClientTask);
-        _logger.LogInformation("Proxy connection closed, exiting...");
+        _logger.LogInformation("Proxy connection closed");
     }
 }


### PR DESCRIPTION
Fixes #8 by wrapping the proxy write in a try-catch.

I also refactored how the overrides are applied, which removed a bunch of duplicate code - including some proxy write we would have had to all wrap in try-catch blocks.