### PR TITLE
Add tosVersion parameter when overriding login if present in original packet

### DIFF
--- a/src/server/EA/Proxy/FeslProxy.cs
+++ b/src/server/EA/Proxy/FeslProxy.cs
@@ -314,6 +314,13 @@ public partial class FeslProxy
                 { "password", _proxySettings.ProxyOverrideAccountPassword },
                 { "macAddr", macAddr },
             };
+            
+            // Add tosVersion param if present in the original packet, so this login can update the TOS version
+            var tosVersion = packet["tosVersion"];
+            if (!string.IsNullOrWhiteSpace(tosVersion))
+            {
+                overridePacketData["tosVersion"] = tosVersion;
+            }
 
             packet = new Packet("acct", FeslTransmissionType.SinglePacketRequest, packet.Id, overridePacketData);
             numOverridesApplied++;


### PR DESCRIPTION
Fixes #12 by simply copying the `tosVersion` parameter from the original packet to the override packet (if present).