### PR TITLE
Add option to override account creation

### DIFF
--- a/src/server/AppSettings.cs
+++ b/src/server/AppSettings.cs
@@ -33,6 +33,7 @@ public record ProxySettings
     public bool ProxyOverrideAccountIsXbox { get; init; } = false;
     public string ProxyOverrideAccountEmail { get; init; } = string.Empty;
     public string ProxyOverrideAccountPassword { get; init; } = string.Empty;
+    public string ProxyOverrideAccountAddPersonaName { get; init; } = string.Empty;
     public int ProxyOverridePlayNowGameGid { get; init; } = 0;
     public int ProxyOverridePlayNowGameLid { get; init; } = 0;
 }

--- a/src/server/appsettings.json
+++ b/src/server/appsettings.json
@@ -19,6 +19,7 @@
         "ProxyOverrideAccountIsXbox": false,
         "ProxyOverrideAccountEmail": "",
         "ProxyOverrideAccountPassword": "",
+        "ProxyOverrideAccountAddPersonaName": "",
         "ProxyOverridePlayNowGameGid": 0,
         "ProxyOverridePlayNowGameLid": 0
     },


### PR DESCRIPTION
Adds the option to create an account in game, replacing the `NuPS3AddAccount` call, which contains a PS3 ticket, with a `NuAddAccount` call containing an email and password.

The overall flow of the account creation with the override enabled is:
```
-> Login
<- User not found
[Agree to TOS]
[Confirm empty signup form]
-> AddAccount
<- Account created
-> Login
<- lkey
-> GetPersonas
<- empty list
-> AddPersona
<- Persona created
-> LoginPersona
<- lkey
-> Theater login
...
```