### PR TITLE
Add option to override minimum players required to start private match

### DIFF
--- a/src/server/AppSettings.cs
+++ b/src/server/AppSettings.cs
@@ -36,6 +36,7 @@ public record ProxySettings
     public string ProxyOverrideAccountAddPersonaName { get; init; } = string.Empty;
     public int ProxyOverridePlayNowGameGid { get; init; } = 0;
     public int ProxyOverridePlayNowGameLid { get; init; } = 0;
+    public int ProxyOverridePrivateMatchMinPlayers { get; init; } = 0;
 }
 
 public record DnsSettings

--- a/src/server/EA/Proxy/FeslProxy.cs
+++ b/src/server/EA/Proxy/FeslProxy.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using Arcadia.EA.Constants;
@@ -236,6 +237,22 @@ public partial class FeslProxy
 
             packet = new Packet("acct", FeslTransmissionType.SinglePacketRequest, packet.Id, overridePacketData);
             numOverridesApplied++;
+        }
+
+        var enablePrivateMatchMinPlayersOverride = _proxySettings.ProxyOverridePrivateMatchMinPlayers != 0;
+        if (enablePrivateMatchMinPlayersOverride &&
+            type == "rank" &&
+            transmissionType == FeslTransmissionType.SinglePacketResponse &&
+            txn == "GetStats")
+        {
+            var firstKey = packet["stats.1.key"];
+            if (firstKey == "pm_minplayers")
+            {
+                _logger.LogInformation("Overriding pm_minplayers...");
+                
+                packet["stats.1.value"] = _proxySettings.ProxyOverridePrivateMatchMinPlayers.ToString("0.0", CultureInfo.InvariantCulture);
+                numOverridesApplied++;
+            }
         }
 
         var enablePlatformOverride = _proxySettings.ProxyOverrideAccountIsXbox;

--- a/src/server/appsettings.json
+++ b/src/server/appsettings.json
@@ -21,7 +21,8 @@
         "ProxyOverrideAccountPassword": "",
         "ProxyOverrideAccountAddPersonaName": "",
         "ProxyOverridePlayNowGameGid": 0,
-        "ProxyOverridePlayNowGameLid": 0
+        "ProxyOverridePlayNowGameLid": 0,
+        "ProxyOverridePrivateMatchMinPlayers": 0
     },
     "DnsSettings": {
         "EnableDns": false,


### PR DESCRIPTION
Exactly what it says. The number of players required to start a private match is sent by FESL. This adds a simple override option for that numbers.

Open TODOs:
- [x] Test if Theater lets you start a match with fewer than the usual 16 players